### PR TITLE
Add JSON-LD recipe schema markup

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,9 +1,17 @@
 // @ts-check
+import { rehypeHeadingIds } from '@astrojs/markdown-remark';
 import { defineConfig } from 'astro/config';
+import { recipeSchemaMarkupGenerator } from './lib/plugins';
 
 // https://astro.build/config
 export default defineConfig({
-    site: "https://foss.cooking",
-    // reidrects abc.xyz/ -> abc.xyz
+    markdown: {
+        rehypePlugins: [
+	    rehypeHeadingIds,
+	    recipeSchemaMarkupGenerator,
+	],
+    },
+    site: 'https://foss.cooking',
+    // redirects abc.xyz/ -> abc.xyz
     trailingSlash: 'never'
 });

--- a/lib/plugins/index.js
+++ b/lib/plugins/index.js
@@ -1,0 +1,1 @@
+export * from './recipeSchemaMarkupGenerator';

--- a/lib/plugins/recipe.schema.json
+++ b/lib/plugins/recipe.schema.json
@@ -1,0 +1,84 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "title": "Recipe",
+    "type": "object",
+    "required": ["@context", "@type", "name", "author", "recipeIngredient", "recipeInstructions"],
+    "properties": {
+	"@context": {
+	    "type": "string",
+	    "const": "https://schema.org"
+	},
+	"@type": {
+	    "type": "string",
+	    "const": "Recipe"
+	},
+	"name": {
+	    "type": "string"
+	},
+	"author": {
+	    "type": "string"
+	},
+	"description": {
+	    "type": "string"
+	},
+	"image": {
+	    "type": "array",
+	    "items": {
+		"type": "string"
+	    }
+	},
+	"keywords": {
+	    "type": "array",
+	    "items": {
+		"type": "string"
+	    }
+	},
+	"datePublished": {
+	    "type": "string",
+	    "format": "date"
+	},
+	"recipeYield": {
+	    "type": "string"
+	},
+	"recipeIngredient": {
+	    "type": "array",
+	    "items": {
+		"type": "string"
+	    }
+	},
+	"recipeInstructions": {
+	    "oneOf": [
+		{
+		    "type": "array",
+		    "items": {
+			"type": "string"
+		    }
+		},
+		{
+		    "type": "array",
+		    "items": {
+			"type": "object",
+			"required": ["@type", "name", "itemListElement"],
+			"properties": {
+			    "@type": {
+				"type": "string",
+				"const": "HowToSection"
+			    },
+			    "name": {
+				"type": "string"
+			    },
+			    "itemListElement": {
+				"type": "array",
+				"items": {
+				    "type": "string"
+				}
+			    }
+			},
+			"additionalProperties": true
+		    }
+		}
+	    ]
+	}
+    },
+    "additionalProperties": true
+}

--- a/lib/plugins/recipeSchemaMarkupGenerator.js
+++ b/lib/plugins/recipeSchemaMarkupGenerator.js
@@ -1,0 +1,158 @@
+import Ajv from 'ajv';
+import addFormats from 'ajv-formats';
+import { h } from 'hastscript';
+import { fromString } from 'hast-util-from-string';
+import { toText } from 'hast-util-to-text';
+import { select, selectAll } from 'hast-util-select';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { visit, SKIP, EXIT } from 'unist-util-visit';
+
+const myDirname = path.dirname(fileURLToPath(import.meta.url));
+const recipeSchema = JSON.parse(
+    fs.readFileSync(path.join(myDirname, 'recipe.schema.json'))
+);
+
+const getRecipeIngredients = (tree) => {
+    const ingredientsListItems = selectAll('#ingredients ~ ul > li', tree);
+
+    // Some recipes have sublists of ingredients for components of the dish.
+    const sublists = selectAll('ul', ingredientsListItems);
+    if (sublists.length > 0) {
+	return sublists.reduce((ings, sublist) => [...ings, selectAll('li', sublist).map(toText)], []);
+    } else {
+	// Most recipes have one or more flat lists of ingredients.
+	return ingredientsListItems.map(toText);
+    }
+};
+
+const getRecipeInstructions = (tree) => {
+    const directionsSections = selectAll('#directions ~ h3', tree);
+    if (directionsSections.length > 0) {
+	const initialDirections = [];
+	// Some recipes have sections for different components or variations
+	// (e.g. the Eggs recipe)
+	// Also, it's possible that a section might not have its own heading (e.g. Omelet)
+	const unlabeledSection = select('#directions + ul, #directions + ol, #directions + p');
+	if (unlabeledSection) {
+	    initialDirections.push({
+		'@type': 'HowToSection',
+		name: title,
+		itemListElement: getRecipeInstructions(unlabeledSection),
+	    });
+	}
+	return directionsSections.reduce((sects, heading) => {
+	    const { id } = heading.properties;
+	    const directions = selectAll(`#${id} + ol > li, #${id} + ul > li, #${id} + p`, tree).map(toText);
+	    if (directions.length > 0) {
+		return [...sects, {
+		    '@type': 'HowToSection',
+		    name: toText(heading),
+		    itemListElement: directions
+		}];
+	    } else {
+		return sects;
+	    }
+	}, initialDirections);
+    } else if (select('#directions ~ ol, #directions ~ ul', tree)) {
+	// Most recipes have their directions in an ordered or unordered list.
+	return selectAll('#directions ~ ol > li, #directions ~ ul > li', tree).map(toText);
+    } else {
+	// A few recipes have their directions in paragraph form.
+	return selectAll('#directions ~ p', tree).map(toText);
+    }
+}
+
+export const recipeSchemaMarkupGenerator = () => (tree, file) => {
+    const { author, date, tags, title } = file.data.astro.frontmatter;
+
+    const authorFileName = `${author.toLowerCase().replaceAll(' ', '-')}.json`;
+    let authorName;
+    try {
+	const authorJson = JSON.parse(
+	    fs.readFileSync(
+		path.join(myDirname, '..', '..', 'src', 'content', 'authors', authorFileName)
+	    )
+	);
+	authorName = authorJson.name;
+    } catch (e) {
+	// fall back to file data author name if we can't read the JSON
+	authorName = author;
+    }
+
+    let recipeData = {
+	"@context": "https://schema.org",
+	"@type": "Recipe",
+	author: authorName,
+	datePublished: date.toISOString().split('T')[0],
+	name: title,
+	keywords: tags,
+    };
+
+    let description = '';
+    const imageElements = [];
+    visit(tree, 'element', (el) => {
+	if (el.children.length > 0 && el.children[0].tagName === 'img') {
+	    imageElements.push(el.children[0]);
+	    return SKIP;
+	} else if (el.tagName === 'ul') {
+	    visit(el.children, 'element', li => {
+		const liText = toText(li);
+		if (liText.includes('Servings')) {
+		    const servingTextParts = liText.trim().split(':');
+		    if (servingTextParts.length === 2) {
+			recipeData.recipeYield = servingTextParts[1];
+		    }
+		}
+		// TODO add prep/cook time.
+		// Kind of a pain to convert free text to ISO 8601 durations.
+	    });
+	    return SKIP;
+	} else if (el.tagName === 'h2') {
+	    return EXIT;
+	} else {
+	    description += toText(el) + ' ';
+	}
+    });
+
+    if (description) {
+	recipeData.description = description.trim();
+    }
+
+    if (imageElements.length > 0) {
+	recipeData.image = imageElements.map(img => {
+	    return `https://foss.cooking${img.properties.src}`;
+	});
+    }
+
+    const ingredients = getRecipeIngredients(tree);
+    if (ingredients.length > 0) {
+	recipeData.recipeIngredient = ingredients;
+    } else {
+	console.warn(`Could not parse ingredients list for ${title}`);
+	return;
+    }
+
+    const recipeInstructions = getRecipeInstructions(tree);
+    if (recipeInstructions.length > 0) {
+	recipeData.recipeInstructions = recipeInstructions;
+    } else {
+	console.warn(`Could not parse directions list for ${title}`);
+	return;
+    }
+
+    // validate
+    const ajv = new Ajv();
+    addFormats(ajv, ['date']);
+    const validate = ajv.compile(recipeSchema);
+    if (!validate(recipeData)) {
+	console.warn(`Generated JSON-LD Recipe markup was invalid for ${title}\n`, validate.errors);
+	return;
+    }
+
+    // add json+ld element to tree if validation succeeds
+    const jsonLdNode = h('script', { type: 'application/json+ld' });
+    fromString(jsonLdNode, JSON.stringify(recipeData));
+    tree.children.push(jsonLdNode);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,14 @@
       "name": "foss.cooking",
       "version": "0.0.1",
       "dependencies": {
-        "astro": "^5.2.5"
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "astro": "^5.2.5",
+        "hast-util-from-string": "^3.0.1",
+        "hast-util-select": "^6.0.4",
+        "hast-util-to-text": "^4.0.2",
+        "hastscript": "^9.0.1",
+        "unist-util-visit": "^5.0.0"
       }
     },
     "node_modules/@astrojs/compiler": {
@@ -467,6 +474,39 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/ajv": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/ansi-align": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
@@ -698,6 +738,16 @@
       "integrity": "sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg==",
       "license": "MIT"
     },
+    "node_modules/bcp-47-match": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/bcp-47-match/-/bcp-47-match-2.0.3.tgz",
+      "integrity": "sha512-JtTezzbAibu8G0R9op9zb3vcWZd9JF6M0xOYGPn0fNCd7wOpRB1mU2mH9T8gaBGbAAyIIVgB2G7xG0GP98zMAQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -709,6 +759,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "license": "ISC"
     },
     "node_modules/boxen": {
       "version": "8.0.1",
@@ -953,6 +1009,22 @@
         "uncrypto": "^0.1.3"
       }
     },
+    "node_modules/css-selector-parser": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/css-selector-parser/-/css-selector-parser-3.1.2.tgz",
+      "integrity": "sha512-WfUcL99xWDs7b3eZPoRszWVfbNo8ErCF15PTvVROjkShGlAfjIkG6hlfj/sl6/rfo5Q9x9ryJ3VqVnAZDA+gcw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/mdevils"
+        },
+        {
+          "type": "patreon",
+          "url": "https://patreon.com/mdevils"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -1064,6 +1136,19 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
+      }
+    },
+    "node_modules/direction": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/direction/-/direction-2.0.1.tgz",
+      "integrity": "sha512-9S6m9Sukh1cZNknO1CWAr2QAWsbKLafQiyM5gZ7VgXHeuaoUwffKN4q6NC4A/Mf9iiPlOXQEKW/Mv/mh9/3YFA==",
+      "license": "MIT",
+      "bin": {
+        "direction": "cli.js"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/dlv": {
@@ -1197,6 +1282,12 @@
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
     },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
     "node_modules/fast-glob": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
@@ -1212,6 +1303,22 @@
       "engines": {
         "node": ">=8.6.0"
       }
+    },
+    "node_modules/fast-uri": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.6.tgz",
+      "integrity": "sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fastq": {
       "version": "1.19.0",
@@ -1370,6 +1477,32 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hast-util-from-string": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-from-string/-/hast-util-from-string-3.0.1.tgz",
+      "integrity": "sha512-EpOi8Ux+QiJEUhv69d0xtGlA/7o6V1Yr4jqy6hq0s71mgl9sJsdruRrCo9UMVLMg+VwBVB4dnut/qsOsem5WWA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-has-property": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-has-property/-/hast-util-has-property-3.0.0.tgz",
+      "integrity": "sha512-MNilsvEKLFpV604hwfhVStK0usFY/QmM5zX16bo7EjnAEGofr5YyI37kzopBlZJkHD4t887i+q/C8/tr5Q94cA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-is-element": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz",
@@ -1421,6 +1554,43 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hast-util-select": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/hast-util-select/-/hast-util-select-6.0.4.tgz",
+      "integrity": "sha512-RqGS1ZgI0MwxLaKLDxjprynNzINEkRHY2i8ln4DDjgv9ZhcYVIHN9rlpiYsqtFwrgpYU361SyWDQcGNIBVu3lw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "bcp-47-match": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "css-selector-parser": "^3.0.0",
+        "devlop": "^1.0.0",
+        "direction": "^2.0.0",
+        "hast-util-has-property": "^3.0.0",
+        "hast-util-to-string": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "nth-check": "^2.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-select/node_modules/property-information": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
+      "integrity": "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/hast-util-to-html": {
       "version": "9.0.4",
       "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.4.tgz",
@@ -1463,6 +1633,19 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hast-util-to-string": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-to-string/-/hast-util-to-string-3.0.1.tgz",
+      "integrity": "sha512-XelQVTDWvqcl3axRfI0xSeoVKzyIFPwsAGSLIsKdJKQMXDYJS4WYrBNF/8J7RdhIcFI2BOHgAifggsvsxp/3+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-to-text": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/hast-util-to-text/-/hast-util-to-text-4.0.2.tgz",
@@ -1493,20 +1676,30 @@
       }
     },
     "node_modules/hastscript": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-9.0.0.tgz",
-      "integrity": "sha512-jzaLBGavEDKHrc5EfFImKN7nZKKBdSLIdGvCwDZ9TfzbF2ffXiov8CKE445L2Z1Ek2t/m4SKQ2j6Ipv7NyUolw==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-9.0.1.tgz",
+      "integrity": "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==",
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0",
         "comma-separated-tokens": "^2.0.0",
         "hast-util-parse-selector": "^4.0.0",
-        "property-information": "^6.0.0",
+        "property-information": "^7.0.0",
         "space-separated-tokens": "^2.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hastscript/node_modules/property-information": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
+      "integrity": "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/html-escaper": {
@@ -1679,6 +1872,12 @@
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
     },
     "node_modules/kleur": {
       "version": "4.1.5",
@@ -2682,6 +2881,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
     "node_modules/ofetch": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/ofetch/-/ofetch-1.4.1.tgz",
@@ -3165,6 +3376,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/retext": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,13 @@
     "clean": "rm -rf .astro dist"
   },
   "dependencies": {
-    "astro": "^5.2.5"
+    "ajv": "^8.17.1",
+    "ajv-formats": "^3.0.1",
+    "astro": "^5.2.5",
+    "hast-util-from-string": "^3.0.1",
+    "hast-util-select": "^6.0.4",
+    "hast-util-to-text": "^4.0.2",
+    "hastscript": "^9.0.1",
+    "unist-util-visit": "^5.0.0"
   }
 }


### PR DESCRIPTION
Fixes #9.

Adds a rehype plugin that generates JSON-LD Recipe schema markup for each recipe and inserts it into the generated HTML.

It's slightly complicated since there is some inconsistency in formatting between recipes. I've tried to account for every case I found. It does generate technically valid JSON-LD for every recipe, but a few recipes have some wonky formatting and have some weird JSON-LD values as a result (for example, cook/prep times being in the description since they weren't added as list items). Perhaps there should be some more consistency enforced on the formatting of recipes (which is probably going to be necessary for #8, it would be very tedious to implement that for all recipes right now).

There's still a TODO to add cook/prep time properties to the JSON-LD. The schema definition requires an ISO 8601 Duration format which is a bit of a pain to create from a free text field and I don't feel like doing that right now (they aren't required properties anyway)