### PR TITLE
reduce title sizes and overflows for small screen friendliness

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -42,7 +42,7 @@ const tags = await getTags();
 	h1 {
 		margin-top: 40px;
 		margin-bottom: 0;
-		font-size: 3rem;
+		font-size: 2rem;
 	}
 	h1,h2 {
 		text-align: center;
@@ -53,10 +53,5 @@ const tags = await getTags();
 	}
 	span {
 		color: var(--primary);
-	}
-	@media screen and (max-width: 600px) {
-		h1 {
-			font-size: 2rem;
-		}	
 	}
 </style>

--- a/src/pages/recipe/[recipe].astro
+++ b/src/pages/recipe/[recipe].astro
@@ -31,10 +31,10 @@ let auth_obj = await getEntry(
         <header>
             <h1>{title}</h1>
             <div id="links">
-            <h2><a href="/">Home</a></h2>
+            <span><a href="/">Home</a></span>
             <!-- @ts-ignore -->
-            <h2><a href=`/author/${auth_obj.id}`>Author</a></h2>
-            <h2><a id="back">Back</a></h2>
+            <span><a href=`/author/${auth_obj.id}`>Author</a></span>
+            <span><a id="back">Back</a></span>
             </div>
         </header>
         <hr>
@@ -57,11 +57,12 @@ let auth_obj = await getEntry(
     }
     h1 {
         margin: 0;
-        font-size: 4rem;
+        font-size: 2rem;
         text-align: center;
     }
     #links {
         display: flex;
+        gap: 0.5em;
     }
     h2 {
         margin: 0;
@@ -69,6 +70,7 @@ let auth_obj = await getEntry(
     }
     article {
         max-width: 800px;
+        width: 90%;
         margin: auto;
     }
     h3 {
@@ -78,17 +80,20 @@ let auth_obj = await getEntry(
     }
     ul {
         display: flex;
+        flex-wrap: wrap;
         justify-content: center;
         padding: 0;
     }
     li {
         list-style: none;
-        padding: 10px;
+        padding-left: 10px;
+        padding-right: 10px;
     }
 </style>
 <!-- is:global is required to reach inside the Content element -->
 <style is:global>
     img {
+        width: 100%;
         max-width: 400px;
         max-height: 400px;
         margin: auto;

--- a/src/partials/base.astro
+++ b/src/partials/base.astro
@@ -67,8 +67,8 @@ const page_url = site + url.pathname.substring(1);
 <style is:global>
     :root {
         font-family: Arial, Helvetica, sans-serif;
-        font-size: 20px;
-        line-height: 30px;
+        font-size: 1rem;
+        line-height: 1.5rem;
 
         --header-size: 3rem;
         --header-weight: 800;


### PR DESCRIPTION
Fixes #22.
I did not have npm installed on my machine so I could not run astro myself. Instead I tested these changes manually in the browser console. Hope they don’t interfere with the intended look of the site.

Basically, I

- made h1 consistently 2rem
- made body text 1rem
- made nav links spans instead of h2

- added margins to the sides on mobile by adding width: 90% to article
- prevented overflows for images and the tags list on mobile